### PR TITLE
init: fix -proxy network specification in tor.md and -help

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -39,7 +39,7 @@ outgoing connections, but more is possible.
         as well. You need to use -noonion or -onion=0 to explicitly disable
         outbound access to onion services.
 
-    -proxy=ip[:port]=tor
+    -proxy=ip[:port]=onion
     or
     -onion=ip[:port]
         Set the proxy server for reaching .onion addresses. You do not need to
@@ -51,7 +51,8 @@ outgoing connections, but more is possible.
         -proxy=addr:port=ipv4 or
         -proxy=addr:port=ipv6
         (last one if multiple options are given). It is not taken from
-        -proxy=addr:port=tor or
+        -proxy=addr:port=onion or
+        -proxy=addr:port=cjdns or
         -onion=addr:port.
         If no proxy for DNS requests is configured, then they will be done using
         the functions provided by the operating system, most likely resulting in

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -616,7 +616,7 @@ void SetupServerArgs(ArgsManager& argsman, bool can_listen_ipc)
                    "Connect through SOCKS5 proxy, set -noproxy to disable. " +
                    proxy_doc_for_unix_socket +
                    "Could end in =network to set the proxy only for that network. " +
-                   "The network can be any of ipv4, ipv6, tor or cjdns. " +
+                   "The network can be any of ipv4, ipv6, onion or cjdns. " +
                    "(default: disabled)",
                    ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_ELISION,
                    OptionsCategory::CONNECTION);


### PR DESCRIPTION
This PR updates the `-proxy` documentation in `tor.md`, since tor network specifications have been deprecated.
